### PR TITLE
django-db-log admin interface doesn't work with django 1.2.3 && USE_I18N=True

### DIFF
--- a/djangodblog/admin.py
+++ b/djangodblog/admin.py
@@ -35,7 +35,7 @@ class EfficientPaginator(Paginator):
 class EfficientChangeList(ChangeList):
     def get_results(self, request):
         paginator = EfficientPaginator(self.query_set, self.list_per_page)
-        result_count = ''
+        result_count = paginator.count
 
         # Get the list of objects to display on this page.
         try:


### PR DESCRIPTION
One line in admin.py fixes the bug
